### PR TITLE
Fix issue w/ Cent/RHEL 6/7 causing sshd to fail startup

### DIFF
--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -47,8 +47,13 @@ AuthorizedKeysFile     %h/.ssh/authorized_keys
 
 {%- if server.authorized_keys_command is defined %}
 AuthorizedKeysCommand {{ server.authorized_keys_command.command }}
-AuthorizedKeysCommandUser {{ server.authorized_keys_command.get('user', 'nobody') }}
+{% if (grains['os_family'] == 'RedHat' and grains['osmajorrelease'] != '6') or grains['os_family'] != 'RedHat' %}
+{%- if server.authorized_keys_command.user is defined %}
+AuthorizedKeysCommandUser {{ server.authorized_keys_command.get('User', 'nobody') }}
 {%- endif %}
+{%- endif %}
+{%- endif %}
+
 
 {% if server.get('deny_users', False) %}
 DenyUsers {{ server.deny_users|join(' ') }}


### PR DESCRIPTION
CentOS/RHEL 7 require AuthorizedKeysCommandUser if AuthorizedKeysCommand is used. 6 however will fail if this value is present. I am unsure what debian, various version and variants will do, so adding server.authorized_keys_command.user is advantageous in that you will be able to have the option of this being present or not even if you can't span osmajorversions.