### PR TITLE
Update SSH(D) Security Configuration

### DIFF
--- a/openssh/files/ssh_config
+++ b/openssh/files/ssh_config
@@ -8,6 +8,10 @@
     'gssapi_delegate_credentials': False,
     'pubkey_authentication': True,
     'forward_agent': False,
+    'HostKeyAlgorithms': 'ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ssh-ed25519,ssh-rsa,ecdsa-sha2-nistp521-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256',
+    'KexAlgorithms': 'curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256',
+    'MACs': 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com',
+    'Ciphers': 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr',
     } %}
 
 {%- macro host_config(pattern, cfg) %}

--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -17,13 +17,32 @@ ListenAddress {{ server.bind.address }}
 
 Protocol 2
 # HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
+{%- if server.get('dsa_enabled', false) %}
 HostKey /etc/ssh/ssh_host_dsa_key
+{%- endif %}
 {%- if grains.os_family != 'CentOS' %}
 HostKey /etc/ssh/ssh_host_ecdsa_key
 {%- endif %}
 #Privilege Separation is turned on for security
 UsePrivilegeSeparation yes
+
+{%- if server.get('kex_algorithms', False) %}
+KexAlgorithms {{ server.kex_algorithms|join(',') }}
+{%- else }
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+{%- endif %}
+{%- if server.get('ciphers', False) %}
+Ciphers {{ server.ciphers|join(',') }}
+{%- else }
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+{%- endif %}
+{%- if server.get('macs', False) %}
+MACs {{ server.macs|join(',') }}
+{%- else }
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+{%- endif %}
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600

--- a/openssh/files/sshd_config
+++ b/openssh/files/sshd_config
@@ -30,17 +30,17 @@ UsePrivilegeSeparation yes
 
 {%- if server.get('kex_algorithms', False) %}
 KexAlgorithms {{ server.kex_algorithms|join(',') }}
-{%- else }
+{%- else %}
 KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 {%- endif %}
 {%- if server.get('ciphers', False) %}
 Ciphers {{ server.ciphers|join(',') }}
-{%- else }
+{%- else %}
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 {%- endif %}
 {%- if server.get('macs', False) %}
 MACs {{ server.macs|join(',') }}
-{%- else }
+{%- else %}
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 {%- endif %}
 


### PR DESCRIPTION
Added the ability to define different security parameters with pillar data, with modern defaults as specified by https://infosec.mozilla.org/guidelines/openssh  