### PR TITLE
Add support to set port of ssh_known_hosts

### DIFF
--- a/openssh/client/known_host.sls
+++ b/openssh/client/known_host.sls
@@ -17,6 +17,9 @@ include:
   - fingerprint_hash_type: {{ host.fingerprint_hash_type }}
   {%- endif %}
   - fingerprint: {{ host.fingerprint }}
+  {%- if host.port is defined %}
+  - port: {{ host.port }}
+  {%- endif %}
   - require:
     - pkg: openssh_client_packages
     - file: {{ user.user.home }}/.ssh


### PR DESCRIPTION
See "port" option in https://docs.saltstack.com/en/latest/ref/states/all/salt.states.ssh_known_hosts.html#salt.states.ssh_known_hosts.present